### PR TITLE
Use dvh for height

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -32,7 +32,7 @@ function Layout({
   return (
     <div className="h-dvh bg-[url(/images/coral.webp)] bg-no-repeat bg-cover bg-center">
       <div className="bg-black/60 h-full flex justify-center items-center">
-        <div className="max-w-3xl container h-screen">
+        <div className="max-w-3xl container h-full">
           <div className="w-full h-full p-5 flex flex-col items-center gap-5">
             <header className="w-full flex justify-center">
               <Link href="/">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -30,7 +30,7 @@ function Layout({
   useDocumentTitle(title);
 
   return (
-    <div className="h-screen bg-[url(/images/coral.webp)] bg-no-repeat bg-cover bg-center">
+    <div className="h-dvh bg-[url(/images/coral.webp)] bg-no-repeat bg-cover bg-center">
       <div className="bg-black/60 h-screen flex justify-center items-center">
         <div className="max-w-3xl container h-screen">
           <div className="w-full h-full p-5 flex flex-col items-center gap-5">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -31,7 +31,7 @@ function Layout({
 
   return (
     <div className="h-dvh bg-[url(/images/coral.webp)] bg-no-repeat bg-cover bg-center">
-      <div className="bg-black/60 h-screen flex justify-center items-center">
+      <div className="bg-black/60 h-full flex justify-center items-center">
         <div className="max-w-3xl container h-screen">
           <div className="w-full h-full p-5 flex flex-col items-center gap-5">
             <header className="w-full flex justify-center">


### PR DESCRIPTION
Fixes the layout height to use `dvh` instead of `h-screen`. This ensures the layout correctly accounts for the dynamic viewport height on mobile devices.